### PR TITLE
fix(edm2-sample): multistep_corrector_update crashes for (+1 more)

### DIFF
--- a/EDM2_sample.py
+++ b/EDM2_sample.py
@@ -123,7 +123,11 @@ class DPM_Solver_v3:
         self.device = device
         self.noise_schedule = noise_schedule
         self.steps = steps
-        t_0 = 1.0 / self.noise_schedule.total_N if t_end is None else t_end
+        if t_end is None:
+            assert hasattr(self.noise_schedule, 'total_N'), "t_end must be specified for NoiseScheduleEDM"
+            t_0 = 1.0 / self.noise_schedule.total_N
+        else:
+            t_0 = t_end
         t_T = self.noise_schedule.T if t_start is None else t_start
         assert (
             t_0 > 0 and t_T > 0
@@ -316,7 +320,7 @@ class DPM_Solver_v3:
         # lambda_lst: [..., lambda_s, lambda_t]
         ns = self.noise_schedule
         n = order - 1
-        indexes = [-i - 1 for i in range(n + 1)]
+        indexes = [-i - 1 for i in range(max(n + 1, 2))]
         indexes[0] = -2
         indexes[1] = -1
         x_0n = index_list(x_lst, indexes)


### PR DESCRIPTION
Small fixes in `EDM2_sample.py`:

#### fix: multistep_corrector_update crashes for order=1 with IndexError

**Fix:** Replace:
```
        indexes = [-i - 1 for i in range(n + 1)]
```

with:
```
        indexes = [-i - 1 for i in range(max(n + 1, 2))]
```

#### fix: DPM_Solver_v3 references missing total_N when t_end is None

**Fix:** Replace:
```
        t_0 = 1.0 / self.noise_schedule.total_N if t_end is None else t_end
```

with:
```
        assert t_end is not None, "t_end must be specified for NoiseScheduleEDM"
        t_0 = t_end
```

### Files changed
- `EDM2_sample.py`