### PR TITLE
fix(var-sample): argparse bool flag --trick does not parse (+1 more)

### DIFF
--- a/VAR_sample.py
+++ b/VAR_sample.py
@@ -26,7 +26,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--cfg", type=float, default=1.0)
 parser.add_argument("--depth", type=int, default=16)
 parser.add_argument("--sample_dir", type=str, default="./samples")
-parser.add_argument("--trick", type=bool, default=False)
+parser.add_argument("--trick", action="store_true")
 
 args = parser.parse_args()
 


### PR DESCRIPTION
Small fixes in `VAR_sample.py`:

#### fix: argparse bool flag --trick does not parse correctly

**Fix:** Replace:
```
parser.add_argument("--trick", type=bool, default=False)
```

with:
```
parser.add_argument("--trick", action="store_true")
```

#### fix: argparse type=bool parses any string as True

**Fix:** Replace:
```
parser.add_argument("--trick", type=bool, default=False)
```

with:
```
parser.add_argument("--trick", action="store_true")
```

### Files changed
- `VAR_sample.py`